### PR TITLE
Feat rollup counts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ WORKDIR /application
 
 ADD . ./
 
-RUN python3 -m pip install .
+RUN python3 -m pip install -e .

--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -5,11 +5,12 @@ import json
 import subprocess
 import warnings
 import shutil
+import pandas as pd
 
 import argh
 from argh import arg
 
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, NamedTemporaryFile
 from pathlib import Path
 from collections import defaultdict
 from concurrent import futures
@@ -31,29 +32,42 @@ except KeyError:
 
 # Utility funcs ----
 
-def retry_on_fail(f, max_retries=2):
-    n_retries = 0
-
-    for n_retries in range(max_retries + 1):
-        try:
-            f()
-        except Exception as e:
-            if n_retries < max_retries:
-                n_retries += 1
-                warnings.warn("Function failed, starting retry: %s" % n_retries)
-            else:
-                raise e
-
-def put_file(fs, src, dst):
-    retry_on_fail(
-        lambda: fs.put(src, dst),
-        2
-    )
 
 def json_to_newline_delimited(in_file, out_file):
     data = json.load(open(in_file))
     with open(out_file, "w") as f:
         f.write("\n".join([json.dumps(record) for record in data]))
+
+
+def parse_pb_name_data(file_name):
+    """Returns data encoded in extraction files, such as datetime or itp id.
+
+    >>> parse_pb_name_data("2021-01-01__1__0__filename__etc")
+    {'dt': '2021-01-01', 'itp_id': 1, 'url_number': 0, 'src_fname': 'filename'}
+
+    """
+
+    dt, itp_id, url_number, src_fname, *_ = Path(file_name).name.split("__")
+    return dict(
+            dt = dt,
+            itp_id = int(itp_id),
+            url_number = int(url_number),
+            src_fname = src_fname)
+
+def build_pb_validator_name(dt, itp_id, url_number, src_fname):
+    """Return name for file in the format needed for validation.
+
+    Note that the RT validator needs to use timestamps at the end of the filename,
+    so this function ensures they are present.
+
+    """
+
+    return RT_FILENAME_TEMPLATE.format(
+        dt=dt,
+        itp_id=itp_id,
+        url_number=url_number,
+        src_fname=src_fname
+    )
 
 # Validation ==================================================================
 
@@ -83,7 +97,7 @@ def validate(gtfs_file, rt_path, verbose=False):
 
 def validate_gcs_bucket(
         project_id, token, gtfs_schedule_path, gtfs_rt_glob_path=None,
-        out_dir=None, results_bucket=None, verbose=False, 
+        out_dir=None, results_bucket=None, verbose=False, aggregate_counts=False,
         ):
     """
     Fetch and validate GTFS RT data held in a google cloud bucket.
@@ -113,7 +127,7 @@ def validate_gcs_bucket(
         tmp_dir = None
         tmp_dir_name = out_dir
 
-    if results_bucket and not results_bucket.endswith("/"):
+    if results_bucket and not aggregate_counts and results_bucket.endswith("/"):
         results_bucket = f"{results_bucket}/"
 
     final_json_dir = Path(tmp_dir_name) / "newline_json"
@@ -133,11 +147,20 @@ def validate_gcs_bucket(
 
 
         download_rt_files(dst_path_rt, fs, glob_path = gtfs_rt_glob_path)
-
         print("Validating data")
         validate(f"{dst_path_gtfs}.zip", dst_path_rt, verbose=verbose)
 
-        if results_bucket:
+        if results_bucket and aggregate_counts:
+            print(f"Saving aggregate counts as: {results_bucket}")
+
+            error_counts = rollup_error_counts(dst_path_rt)
+            df = pd.DataFrame(error_counts)
+
+            with NamedTemporaryFile() as tmp_file:
+                df.to_parquet(tmp_file.name)
+                fs.put(tmp_file.name, results_bucket)
+
+        elif results_bucket and not aggregate_counts:
             # validator stores results as {filename}.results.json
             print(f"Putting data into results bucket: {results_bucket}")
 
@@ -204,12 +227,7 @@ def download_rt_files(dst_dir, fs=None, date="2021-08-01", glob_path=None):
 
         dst_parent.mkdir(parents=True, exist_ok=True)
 
-        out_fname = RT_FILENAME_TEMPLATE.format(
-            itp_id=itp_id,
-            url_number=url_number,
-            dt=dt,
-            src_fname=src_fname
-        )
+        out_fname = build_pb_validator_name(dt, itp_id, url_number, src_fname)
 
         dst_name = str(dst_parent / out_fname)
 
@@ -218,11 +236,32 @@ def download_rt_files(dst_dir, fs=None, date="2021-08-01", glob_path=None):
 
     print(f"Copying {len(to_copy)} files")
 
-    with futures.ThreadPoolExecutor(max_workers=N_THREAD_WORKERS) as pool:
-        list(pool.map(lambda args: fs.get(*args), to_copy))
+    src_files, dst_files = zip(*to_copy)
+    fs.get(list(src_files), list(dst_files))
 
 
 # Rectangling =================================================================
+
+
+def rollup_error_counts(rt_dir):
+    result_files = Path(rt_dir).glob("*.results.json")
+
+    code_counts = []
+    for path in result_files:
+        metadata = parse_pb_name_data(path)
+
+        result_json = json.load(path.open())
+        for entry in result_json:
+            code_counts.append({
+                "calitp_itp_id": metadata["itp_id"],
+                "calitp_url_number": metadata["url_number"],
+                "calitp_extracted_at": metadata["dt"],
+                "rt_feed_type": metadata["src_fname"],
+                "rule_id": entry["errorMessage"]["validationRule"]["errorId"],
+                "n_occurrences": len(entry["occurrenceList"])
+            })
+
+    return code_counts
 
 
 def main():

--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -198,7 +198,9 @@ def validate_gcs_bucket_many(
 
     Additional Arguments:
         strict: whether to raise an error when a validation fails
-        status_result_path: path for saving the status of validations
+        status_result_path: directory for saving the status of validations
+        result_name_prefix: a name to prefix to each result file name. File names
+            will be numbered. E.g. result_0.parquet, result_1.parquet for two feeds.
         
 
     Param CSV should contain the following fields (passed to validate_gcs_bucket):

--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -192,7 +192,7 @@ def validate_gcs_bucket(
 def validate_gcs_bucket_many(
     project_id, token, param_csv,
     results_bucket=None, verbose=False, aggregate_counts=False,
-    status_result_path=None, strict=False,
+    status_result_path=None, strict=False, result_name_prefix="result_"
 ):
     """Validate many gcs buckets using a parameter file.
 
@@ -227,7 +227,7 @@ def validate_gcs_bucket_many(
             validate_gcs_bucket(
                 project_id,
                 token,
-                results_bucket=results_bucket + f"/result_{idx}.parquet",
+                results_bucket=results_bucket + f"/{result_name_prefix}{idx}.parquet",
                 verbose=verbose,
                 aggregate_counts=aggregate_counts,
                 **row[required_cols]

--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -218,6 +218,7 @@ def validate_gcs_bucket_many(
     fs = gcsfs.GCSFileSystem(project_id, token=token)
     params = pd.read_csv(fs.open(param_csv))
 
+    # check that the parameters file has all required columns
     missing_cols = set(required_cols) - set(params.columns)
     if missing_cols:
         raise ValueError("parameter csv missing columns: %s" % missing_cols)

--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -15,10 +15,10 @@ RT_BUCKET_FOLDER="gs://gtfs-data/rt"
 RT_BUCKET_PROCESSED_FOLDER="gs://gtfs-data/rt-processed"
 SCHEDULE_BUCKET_FOLDER="gs://gtfs-data/schedule"
 
-# Note that the final {dt} is needed by the validator, which may read it as
+# Note that the final {extraction_date} is needed by the validator, which may read it as
 # timestamp data. Note that the final datetime requires Z at the end, to indicate
 # it's a ISO instant
-RT_FILENAME_TEMPLATE="{dt}__{itp_id}__{url_number}__{src_fname}__{dt}Z.pb"
+RT_FILENAME_TEMPLATE="{extraction_date}__{itp_id}__{url_number}__{src_fname}__{extraction_date}Z.pb"
 N_THREAD_WORKERS = 30
 
 try:
@@ -40,18 +40,18 @@ def parse_pb_name_data(file_name):
     """Returns data encoded in extraction files, such as datetime or itp id.
 
     >>> parse_pb_name_data("2021-01-01__1__0__filename__etc")
-    {'dt': '2021-01-01', 'itp_id': 1, 'url_number': 0, 'src_fname': 'filename'}
+    {'extraction_date': '2021-01-01', 'itp_id': 1, 'url_number': 0, 'src_fname': 'filename'}
 
     """
 
-    dt, itp_id, url_number, src_fname, *_ = Path(file_name).name.split("__")
+    extraction_date, itp_id, url_number, src_fname, *_ = Path(file_name).name.split("__")
     return dict(
-            dt = dt,
+            extraction_date = extraction_date,
             itp_id = int(itp_id),
             url_number = int(url_number),
             src_fname = src_fname)
 
-def build_pb_validator_name(dt, itp_id, url_number, src_fname):
+def build_pb_validator_name(extraction_date, itp_id, url_number, src_fname):
     """Return name for file in the format needed for validation.
 
     Note that the RT validator needs to use timestamps at the end of the filename,
@@ -60,11 +60,10 @@ def build_pb_validator_name(dt, itp_id, url_number, src_fname):
     """
 
     return RT_FILENAME_TEMPLATE.format(
-        dt=dt,
+        extraction_date=extraction_date,
         itp_id=itp_id,
         url_number=url_number,
-        src_fname=src_fname,
-        dashed_dt=dt.replace(":", "-")
+        src_fname=src_fname
     )
 
 # Validation ==================================================================
@@ -312,7 +311,7 @@ def rollup_error_counts(rt_dir):
             code_counts.append({
                 "calitp_itp_id": metadata["itp_id"],
                 "calitp_url_number": metadata["url_number"],
-                "calitp_extracted_at": metadata["dt"],
+                "calitp_extracted_at": metadata["extraction_date"],
                 "rt_feed_type": metadata["src_fname"],
                 "rule_id": entry["errorMessage"]["validationRule"]["errorId"],
                 "n_occurrences": len(entry["occurrenceList"])

--- a/script/seed_bucket_data.py
+++ b/script/seed_bucket_data.py
@@ -19,7 +19,7 @@ fs.copy(
     recursive=True
 )
 
-# create a parameter file for validate_gcs_bucket_many ----
+# create a 1 row parameter file for validate_gcs_bucket_many ----
 params = pd.DataFrame({
     "gtfs_schedule_path": ["gs://calitp-py-ci/gtfs-rt-validator-api/gtfs_schedule_126"],
     "gtfs_rt_glob_path": ["gs://calitp-py-ci/gtfs-rt-validator-api/gtfs_rt_126/2021*/126/0/*"]
@@ -28,5 +28,21 @@ params = pd.DataFrame({
 # save to gcs
 fs.pipe(
     "gs://calitp-py-ci/gtfs-rt-validator-api/validation_params.csv",
-    params.to_csv().encode(),
+    params.to_csv(index=False).encode(),
+)
+
+
+# create a 25 row parameter file, pointing to production data ----
+feeds = fs.ls("gtfs-data/rt/2021-10-01T00:00:11/")
+itp_ids = [x.split('/')[-1] for x in feeds]
+
+gtfs_schedules = [f"gs://gtfs-data/schedule/2021-10-01T00:00:00+00:00/{id}_0" for id in itp_ids]
+gtfs_rt = [f"gs://gtfs-data/rt/2021-10-01T00:00:*/{id}/0/*" for id in itp_ids]
+
+params_many = pd.DataFrame({"gtfs_schedule_path": gtfs_schedules, "gtfs_rt_glob_path": gtfs_rt})
+
+# save to gcs
+fs.pipe(
+    "gs://calitp-py-ci/gtfs-rt-validator-api/validation_params_many.csv",
+    params_many.to_csv(index=False).encode(),
 )

--- a/script/seed_bucket_data.py
+++ b/script/seed_bucket_data.py
@@ -1,4 +1,5 @@
 # this script is used to push test data to a cloud bucket, to be used for tests.
+import pandas as pd
 from calitp.storage import get_fs
 
 fs = get_fs()
@@ -16,4 +17,16 @@ fs.copy(
         "gs://gtfs-data/schedule/2021-10-01T00:00:00+00:00/126_0",
     "gs://calitp-py-ci/gtfs-rt-validator-api/gtfs_schedule_126",
     recursive=True
+)
+
+# create a parameter file for validate_gcs_bucket_many ----
+params = pd.DataFrame({
+    "gtfs_schedule_path": ["gs://calitp-py-ci/gtfs-rt-validator-api/gtfs_schedule_126"],
+    "gtfs_rt_glob_path": ["gs://calitp-py-ci/gtfs-rt-validator-api/gtfs_rt_126/2021*/126/0/*"]
+    })
+
+# save to gcs
+fs.pipe(
+    "gs://calitp-py-ci/gtfs-rt-validator-api/validation_params.csv",
+    params.to_csv().encode(),
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     entry_points={
         'console_scripts': ['gtfs-rt-validator-api=gtfs_rt_validator_api:main'],
     },
-    install_requires=["argh", "gcsfs"],
+    install_requires=["argh", "gcsfs", "pyarrow"],
     python_requires=">=3.6",
     # long_description=README,
     # long_description_content_type="text/markdown",

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -72,3 +72,22 @@ def test_validate_gcs_bucket(tmp_gcs_dir):
     assert "errorMessage" in json.load(fs.open(res_files[0]))
 
 
+def test_validate_gcs_bucket_rollup(tmp_gcs_dir):
+    import pandas as pd
+
+    with TemporaryDirectory() as tmp_dir:
+        validate_gcs_bucket(
+            "cal-itp-data-infra", 
+            None,
+            f"{GCS_BASE_DIR}/gtfs_schedule_126",
+            gtfs_rt_glob_path=f"{GCS_BASE_DIR}/gtfs_rt_126/2021*/126/0/*",
+            out_dir=tmp_dir,
+            results_bucket=tmp_gcs_dir + "/rollup.parquet",
+            aggregate_counts=True
+        )
+
+    fname = f"{tmp_gcs_dir}/rollup.parquet"
+    
+    assert fs.exists(fname)
+    
+    assert (pd.read_parquet(fs.open(fname)).calitp_itp_id == 126).all()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -4,7 +4,7 @@ import json
 
 from tempfile import TemporaryDirectory
 
-from gtfs_rt_validator_api import download_gtfs_schedule_zip, download_rt_files, validate, validate_gcs_bucket
+from gtfs_rt_validator_api import download_gtfs_schedule_zip, download_rt_files, validate, validate_gcs_bucket, validate_gcs_bucket_many
 from calitp.storage import get_fs
 from pathlib import Path
 
@@ -57,7 +57,7 @@ def test_validate_gcs_bucket(tmp_gcs_dir):
 
     with TemporaryDirectory() as tmp_dir:
         validate_gcs_bucket(
-            "cal-itp-data-infra", 
+            "cal-itp-data-infra",
             None,
             f"{GCS_BASE_DIR}/gtfs_schedule_126",
             gtfs_rt_glob_path=f"{GCS_BASE_DIR}/gtfs_rt_126/2021*/126/0/*",
@@ -91,3 +91,16 @@ def test_validate_gcs_bucket_rollup(tmp_gcs_dir):
     assert fs.exists(fname)
     
     assert (pd.read_parquet(fs.open(fname)).calitp_itp_id == 126).all()
+
+
+def test_validate_gcs_bucket_many(tmp_gcs_dir):
+    with TemporaryDirectory() as tmp_dir:
+        validate_gcs_bucket_many(
+            "cal-itp-data-infra", 
+            None,
+            "gs://calitp-py-ci/gtfs-rt-validator-api/validation_params.csv",
+            results_bucket=tmp_gcs_dir + "/rollup.parquet",
+            aggregate_counts=True
+        )
+
+


### PR DESCRIPTION
edit: I'll run black formatting on this code before merging, but didn't want to screw up the diff before then!

* Adds `aggregate_counts` argument to validate_gcs_bucket. When this is set it rolls up counts of errors per file, rather than upload raw results files.
* implements a function called `validate_gcs_bucket_many`, which uses a path to a CSV to validate many feeds.
  - Uploads a file with 1 row per feed, which indicates whether validation was successful
  - e.g. validation can fail if gtfs schedule does not have agency.txt
  - This allows the pipeline to easily wire up this library to validate all (or a specified set) of feeds daily.
* fixes an issue where the validator could not parse the datetime info we put at the end of filenames. Note that the fix was simply to put "Z" at the end.

As a side note, I noticed that the bulk of validation results files are long string descriptions of the rules (repeated per file x 4,000 timepoints per feed per day..). I cobbled together a quick ERD to describe how this info could be pulled out into dimensions, and everything can be wired together here: https://github.com/cal-itp/data-infra/issues/787#issuecomment-987305649

I'll plan to walk through the ERD and some of the data design decisions tomorrow in our meeting with @mjumbewu and @holly-g , but wanted to get this PR up.

Next step would be to implement https://github.com/cal-itp/data-infra/issues/788 in data-infra to produce the parameters csv, and integrate into the validation task!