### PR TITLE
specify output files by feed/url and suffix

### DIFF
--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -134,8 +134,6 @@ def validate_gcs_bucket(
     verbose: bool = False,
     aggregate_counts: bool = False,
     idx: int = None,
-    calitp_itp_id: int = None,
-    calitp_url_number: int = None,
 ):
     """
     Fetch and validate GTFS RT data held in a google cloud bucket.
@@ -150,8 +148,6 @@ def validate_gcs_bucket(
         results_bucket: a bucket path to copy results to.
         verbose: whether to print helpful messages along the way.
         aggregate_counts: tbd
-        calitp_itp_id: not needed, but lazy way to accept a full row
-        calitp_url_number: not needed, but lazy way to accept a full row
 
     Note that if out_dir is unspecified, the validation occurs in a temporary directory.
 
@@ -313,7 +309,8 @@ def validate_gcs_bucket_many(
                 + f"/{result_name_prefix}_{row['calitp_itp_id']}_{row['calitp_url_number']}.parquet",
                 aggregate_counts=aggregate_counts,
                 idx=idx,
-                **row[required_cols],
+                gtfs_schedule_path=row["gtfs_schedule_path"],
+                gtfs_rt_glob_path=row["gtfs_rt_glob_path"],
             ): row
             for idx, row in params.iterrows()
         }

--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -134,6 +134,8 @@ def validate_gcs_bucket(
     verbose: bool = False,
     aggregate_counts: bool = False,
     idx: int = None,
+    calitp_itp_id: int = None,
+    calitp_url_number: int = None,
 ):
     """
     Fetch and validate GTFS RT data held in a google cloud bucket.
@@ -239,12 +241,12 @@ def validate_gcs_bucket_many(
     project_id: str = "cal-itp-data-infra",
     token: str = None,  # "cloud",
     param_csv: str = f"gs://gtfs-data-test/rt-processed/calitp_validation_params/{pendulum.today().to_date_string()}.csv",
-    results_bucket: str = "gs://calitp-py-ci/gtfs-rt-validator-api/test-pipeline",
+    results_bucket: str = f"gs://gtfs-data-test/rt-processed/validation/{pendulum.today().to_date_string()}",
     verbose: bool = True,
     aggregate_counts: bool = True,
-    status_result_path: str = "gs://calitp-py-ci/gtfs-rt-validator-api/test-pipeline/status.json",
+    status_result_path: str = f"gs://gtfs-data-test/rt-processed/validation/{pendulum.today().to_date_string()}/status.json",
     strict: bool = False,
-    result_name_prefix: str = "result_",
+    result_name_prefix: str = "validation_results_",
     threads: int = 1,
     limit: int = None,
 ):
@@ -268,7 +270,12 @@ def validate_gcs_bucket_many(
 
     import gcsfs
 
-    required_cols = ["gtfs_schedule_path", "gtfs_rt_glob_path"]
+    required_cols = [
+        "calitp_itp_id",
+        "calitp_url_number",
+        "gtfs_schedule_path",
+        "gtfs_rt_glob_path",
+    ]
 
     logger.info(f"reading params from {param_csv}")
     fs = gcsfs.GCSFileSystem(project_id, token=token)
@@ -300,7 +307,8 @@ def validate_gcs_bucket_many(
                 project_id,
                 token,
                 verbose=verbose,
-                results_bucket=results_bucket + f"/{result_name_prefix}{idx}.parquet",
+                results_bucket=results_bucket
+                + f"/{result_name_prefix}_{row['calitp_itp_id']}_{row['calitp_url_number']}.parquet",
                 aggregate_counts=aggregate_counts,
                 idx=idx,
                 **row[required_cols],

--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -16,6 +16,7 @@ import pandas as pd
 import pendulum
 import structlog as structlog
 import typer
+from calitp.config import get_bucket
 from structlog import configure
 from structlog.threadlocal import bind_threadlocal, clear_threadlocal, merge_threadlocal
 
@@ -238,11 +239,11 @@ def validate_gcs_bucket(
 def validate_gcs_bucket_many(
     project_id: str = "cal-itp-data-infra",
     token: str = None,  # "cloud",
-    param_csv: str = f"gs://gtfs-data-test/rt-processed/calitp_validation_params/{pendulum.today().to_date_string()}.csv",
-    results_bucket: str = f"gs://gtfs-data-test/rt-processed/validation/{pendulum.today().to_date_string()}",
+    param_csv: str = f"{get_bucket()}/rt-processed/calitp_validation_params/{pendulum.today().to_date_string()}.csv",
+    results_bucket: str = f"{get_bucket()}/rt-processed/validation/{pendulum.today().to_date_string()}",
     verbose: bool = True,
     aggregate_counts: bool = True,
-    status_result_path: str = f"gs://gtfs-data-test/rt-processed/validation/{pendulum.today().to_date_string()}/status.json",
+    status_result_path: str = f"{get_bucket()}/rt-processed/validation/{pendulum.today().to_date_string()}/status.json",
     strict: bool = False,
     result_name_prefix: str = "validation_results",
     threads: int = 1,

--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -150,6 +150,8 @@ def validate_gcs_bucket(
         results_bucket: a bucket path to copy results to.
         verbose: whether to print helpful messages along the way.
         aggregate_counts: tbd
+        calitp_itp_id: not needed, but lazy way to accept a full row
+        calitp_url_number: not needed, but lazy way to accept a full row
 
     Note that if out_dir is unspecified, the validation occurs in a temporary directory.
 

--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -273,6 +273,7 @@ def validate_gcs_bucket_many(
         "calitp_url_number",
         "gtfs_schedule_path",
         "gtfs_rt_glob_path",
+        "output_file_suffix",
     ]
 
     logger.info(f"reading params from {param_csv}")
@@ -306,7 +307,7 @@ def validate_gcs_bucket_many(
                 token,
                 verbose=verbose,
                 results_bucket=results_bucket
-                + f"/{result_name_prefix}_{row['calitp_itp_id']}_{row['calitp_url_number']}.parquet",
+                + f"/{result_name_prefix}_{row['calitp_itp_id']}_{row['calitp_url_number']}_{row['output_file_suffix']}.parquet",
                 aggregate_counts=aggregate_counts,
                 idx=idx,
                 gtfs_schedule_path=row["gtfs_schedule_path"],

--- a/gtfs_rt_validator_api.py
+++ b/gtfs_rt_validator_api.py
@@ -246,7 +246,7 @@ def validate_gcs_bucket_many(
     aggregate_counts: bool = True,
     status_result_path: str = f"gs://gtfs-data-test/rt-processed/validation/{pendulum.today().to_date_string()}/status.json",
     strict: bool = False,
-    result_name_prefix: str = "validation_results_",
+    result_name_prefix: str = "validation_results",
     threads: int = 1,
     limit: int = None,
 ):
@@ -325,7 +325,7 @@ def validate_gcs_bucket_many(
             except Exception as e:
                 if strict:
                     raise e
-                statuses.append({**row, "is_success": False})
+                statuses.append({**row, "is_success": False, "exc": str(e)})
             else:
                 statuses.append({**row, "is_success": True})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ black==19.10b0
 typer==0.4.0
 pendulum==2.1.2
 structlog==21.5.0
-
+calitp==0.0.8

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -122,9 +122,10 @@ def test_validate_gcs_bucket_many(tmp_gcs_dir):
             verbose=True,
             aggregate_counts=True,
             status_result_path=tmp_gcs_dir + "/status.json",
+            strict=True,
         )
 
-    fname = f"{tmp_gcs_dir}/result_0.parquet"
+    fname = f"{tmp_gcs_dir}/validation_results_126_0.parquet"
     df = pd.read_parquet(fs.open(fname))
 
     assert (df.calitp_itp_id == 126).all()
@@ -147,6 +148,7 @@ def test_validate_gcs_bucket_many_25(tmp_gcs_dir):
             verbose=True,
             aggregate_counts=True,
             status_result_path=tmp_gcs_dir + "/status.json",
+            threads=4,
         )
 
     fs = get_fs()
@@ -161,7 +163,7 @@ def test_validate_gcs_bucket_many_25(tmp_gcs_dir):
     assert len(status[~status.is_success]) == 1
 
     # check 1 result file
-    fname = f"{tmp_gcs_dir}/result_0.parquet"
+    fname = f"{tmp_gcs_dir}/validation_results_106_0.parquet"
     df = pd.read_parquet(fs.open(fname))
 
     assert (df.calitp_itp_id == 106).all()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -125,7 +125,7 @@ def test_validate_gcs_bucket_many(tmp_gcs_dir):
             strict=True,
         )
 
-    fname = f"{tmp_gcs_dir}/validation_results_126_0.parquet"
+    fname = f"{tmp_gcs_dir}/validation_results_126_0_all.parquet"
     df = pd.read_parquet(fs.open(fname))
 
     assert (df.calitp_itp_id == 126).all()
@@ -163,7 +163,7 @@ def test_validate_gcs_bucket_many_25(tmp_gcs_dir):
     assert len(status[~status.is_success]) == 1
 
     # check 1 result file
-    fname = f"{tmp_gcs_dir}/validation_results_106_0.parquet"
+    fname = f"{tmp_gcs_dir}/validation_results_106_0_all.parquet"
     df = pd.read_parquet(fs.open(fname))
 
     assert (df.calitp_itp_id == 106).all()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -34,7 +34,7 @@ def tmp_gcs_dir():
     yield dir_name
 
     # clean up by removing directory ----
-    fs.rm(dir_name, recursive=True)
+    # fs.rm(dir_name, recursive=True)
 
 
 def list_results(dir_name):
@@ -121,11 +121,11 @@ def test_validate_gcs_bucket_many(tmp_gcs_dir):
             results_bucket=tmp_gcs_dir,
             verbose=True,
             aggregate_counts=True,
-            status_result_path=tmp_gcs_dir + "/status.json",
+            summary_path=tmp_gcs_dir + "/status.json",
             strict=True,
         )
 
-    fname = f"{tmp_gcs_dir}/validation_results_126_0_all.parquet"
+    fname = f"{tmp_gcs_dir}/validation_results/126/0/everything.parquet"
     df = pd.read_parquet(fs.open(fname))
 
     assert (df.calitp_itp_id == 126).all()
@@ -147,15 +147,15 @@ def test_validate_gcs_bucket_many_25(tmp_gcs_dir):
             results_bucket=tmp_gcs_dir,
             verbose=True,
             aggregate_counts=True,
-            status_result_path=tmp_gcs_dir + "/status.json",
+            summary_path=tmp_gcs_dir + "/status.json",
             threads=4,
         )
 
     fs = get_fs()
-    gcs_files = fs.ls(tmp_gcs_dir)
+    gcs_files = fs.glob(tmp_gcs_dir + "/validation_results/*/*/everything.parquet")
 
     # check that bucket contains the 24 rollups and a status.json
-    assert len([x for x in gcs_files if "result" in x]) == 24
+    assert len([x for x in gcs_files if "everything" in x]) == 24
 
     # check that 1 failed feed is in status
     status = pd.read_json(tmp_gcs_dir + "/status.json", lines=True)
@@ -163,7 +163,7 @@ def test_validate_gcs_bucket_many_25(tmp_gcs_dir):
     assert len(status[~status.is_success]) == 1
 
     # check 1 result file
-    fname = f"{tmp_gcs_dir}/validation_results_106_0_all.parquet"
+    fname = f"{tmp_gcs_dir}/validation_results/106/0/everything.parquet"
     df = pd.read_parquet(fs.open(fname))
 
     assert (df.calitp_itp_id == 106).all()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -34,7 +34,7 @@ def tmp_gcs_dir():
     yield dir_name
 
     # clean up by removing directory ----
-    # fs.rm(dir_name, recursive=True)
+    fs.rm(dir_name, recursive=True)
 
 
 def list_results(dir_name):


### PR DESCRIPTION
First step towards https://github.com/cal-itp/data-infra/issues/787; allows identification of validation files by originating feed, url, and entity type.